### PR TITLE
Hotfix endianess

### DIFF
--- a/bpf_objects.py
+++ b/bpf_objects.py
@@ -892,8 +892,8 @@ class CBPFProgIPv6(CBPFHelper):
                     next_label = self.on_success
                 code.extend([
                     LD(location + nibble * 4, size=4, mode=1, label=f"_v6_{self.loc}_{nibble}"),
-                    AND(int.from_bytes(netmask[nibble*4:nibble*4 + 4]), mode=4),
-                    JEQ([int.from_bytes(address[nibble*4:nibble*4 + 4]), next_label, self.on_failure], mode=7)
+                    AND(int.from_bytes(netmask[nibble*4:nibble*4 + 4], 'big' ), mode=4),
+                    JEQ([int.from_bytes(address[nibble*4:nibble*4 + 4], 'big'), next_label, self.on_failure], mode=7)
                 ])
         else:
             address = int(addr).to_bytes(16, byteorder=big)
@@ -904,7 +904,7 @@ class CBPFProgIPv6(CBPFHelper):
                     next_label = self.on_success
                 code.extend([
                     LD(location + nibble * 4, size=4, mode=1, label=f"_v6_{self.loc}_{nibble}"),
-                    JEQ([int.from_bytes(address[nibble*4:nibble*4 + 4]), next_label, self.on_failure], mode=7)
+                    JEQ([int.from_bytes(address[nibble*4:nibble*4 + 4], 'big'), next_label, self.on_failure], mode=7)
                 ])
         self.add_code(code)
 

--- a/ingress_firewall.py
+++ b/ingress_firewall.py
@@ -340,7 +340,7 @@ def main():
         FLUSHES["{}".format(args["mode"])]()
 
     PREAMBLES["{}".format(args["mode"])]()
-    for (interface, policy) in model["IngressNodeFirewallNodeState"]["interfaceIngressRules"].items():
+    for (interface, policy) in model.items():
         ingress = IngressFirewallPolicy(interface, policy)
         ingress.generate_pcap()
         if args.get("debug"):

--- a/ingress_firewall.py
+++ b/ingress_firewall.py
@@ -168,12 +168,12 @@ PREAMBLE_DATA = [
     "/sbin/iptables -D INPUT -j IFW",
     "/sbin/iptables -X IFW",
     "/sbin/iptables -N IFW",
-    "/sbin/iptables -A INPUT -j IFW",
+    "/sbin/iptables -I INPUT -j IFW",
 
     "/sbin/ip6tables -D INPUT -j IFW",
     "/sbin/ip6tables -X IFW",
     "/sbin/ip6tables -N IFW",
-    "/sbin/ip6tables -A INPUT -j IFW",
+    "/sbin/ip6tables -I INPUT -j IFW",
 ]
 
 CLOSURE_DATA = [
@@ -333,13 +333,26 @@ def main():
         help='flush iptables',
         action='store_true'
     )
+    aparser.add_argument(
+       '--append',
+        help='append iptables',
+        action='store_true',
+        default='false'
+    )
+    aparser.add_argument(
+       '--close',
+        help='close IFW chain in iptables',
+        action='store_true',
+        default='false'
+    )
 
     args = vars(aparser.parse_args())
 
     if (args["flush"]):
         FLUSHES["{}".format(args["mode"])]()
 
-    PREAMBLES["{}".format(args["mode"])]()
+    if (not args["append"]):
+        PREAMBLES["{}".format(args["mode"])]()
     for (interface, policy) in model.items():
         ingress = IngressFirewallPolicy(interface, policy)
         ingress.generate_pcap()
@@ -354,7 +367,9 @@ def main():
         ingress.apply_to_hardware(ACTIVATORS["{}-{}".format(args["mode"], args["backend"])])
 
     ingress.apply_to_hardware(ACTIVATORS["{}-{}".format(args["mode"], args["backend"])])
-    CLOSURES["{}".format(args["mode"])]()
+
+    if (args["close"]):
+        CLOSURES["{}".format(args["mode"])]()
 
 
 if __name__ == "__main__":

--- a/ingress_firewall.py
+++ b/ingress_firewall.py
@@ -333,26 +333,13 @@ def main():
         help='flush iptables',
         action='store_true'
     )
-    aparser.add_argument(
-       '--append',
-        help='append iptables',
-        action='store_true',
-        default='false'
-    )
-    aparser.add_argument(
-       '--close',
-        help='close IFW chain in iptables',
-        action='store_true',
-        default='false'
-    )
 
     args = vars(aparser.parse_args())
 
     if (args["flush"]):
         FLUSHES["{}".format(args["mode"])]()
 
-    if (not args["append"]):
-        PREAMBLES["{}".format(args["mode"])]()
+    PREAMBLES["{}".format(args["mode"])]()
     for (interface, policy) in model.items():
         ingress = IngressFirewallPolicy(interface, policy)
         ingress.generate_pcap()
@@ -368,8 +355,7 @@ def main():
 
     ingress.apply_to_hardware(ACTIVATORS["{}-{}".format(args["mode"], args["backend"])])
 
-    if (args["close"]):
-        CLOSURES["{}".format(args["mode"])]()
+    CLOSURES["{}".format(args["mode"])]()
 
 
 if __name__ == "__main__":

--- a/u32_objects.py
+++ b/u32_objects.py
@@ -535,8 +535,8 @@ class U32ProgIPv6(U32Helper):
                             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                             0xff, 0xff])
         for nibble in range(0,4):
-            value = int.from_bytes(address[nibble*4:nibble*4 + 4])
-            mask = int.from_bytes(netmask[nibble*4:nibble*4 + 4])
+            value = int.from_bytes(address[nibble*4:nibble*4 + 4], 'big')
+            mask = int.from_bytes(netmask[nibble*4:nibble*4 + 4], 'big')
             self.add_code([
                 U32LD(location=location + nibble * 4, size=4),
                 U32SH(shift=0),


### PR DESCRIPTION
- Add some missing endianness flags to 'to_byte' and 'from_byte' functions.
- Remove the extra fields (["IngressNodeFirewallNodeState"]["interfaceIngressRules"]) from the passed in json.
- Modify the IFW chain to be the first in the INPUT table.

```
sh-4.4# iptables -L
Chain KUBE-FIREWALL (2 references)
target     prot opt source               destination         
DROP       all  -- !localhost/8          localhost/8          /* block incoming localnet connections */ ! ctstate RELATED,ESTABLISHED,DNAT

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
KUBE-PROXY-FIREWALL  all  --  anywhere             anywhere             ctstate NEW /* kubernetes load balancer firewall */
KUBE-SERVICES  all  --  anywhere             anywhere             ctstate NEW /* kubernetes service portals */
KUBE-FIREWALL  all  --  anywhere             anywhere            

Chain INPUT (policy ACCEPT)
target     prot opt source               destination         
IFW        all  --  anywhere             anywhere            
KUBE-PROXY-FIREWALL  all  --  anywhere             anywhere             ctstate NEW /* kubernetes load balancer firewall */
KUBE-NODEPORTS  all  --  anywhere             anywhere             /* kubernetes health check service ports */
KUBE-EXTERNAL-SERVICES  all  --  anywhere             anywhere             ctstate NEW /* kubernetes externally-visible service portals */
KUBE-FIREWALL  all  --  anywhere             anywhere            

Chain KUBE-KUBELET-CANARY (0 references)
target     prot opt source               destination         

Chain KUBE-PROXY-CANARY (0 references)
target     prot opt source               destination         

Chain KUBE-EXTERNAL-SERVICES (2 references)
target     prot opt source               destination         

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         
KUBE-PROXY-FIREWALL  all  --  anywhere             anywhere             ctstate NEW /* kubernetes load balancer firewall */
KUBE-FORWARD  all  --  anywhere             anywhere             /* kubernetes forwarding rules */
KUBE-SERVICES  all  --  anywhere             anywhere             ctstate NEW /* kubernetes service portals */
KUBE-EXTERNAL-SERVICES  all  --  anywhere             anywhere             ctstate NEW /* kubernetes externally-visible service portals */

Chain KUBE-NODEPORTS (1 references)
target     prot opt source               destination         

Chain KUBE-SERVICES (2 references)
target     prot opt source               destination         

Chain KUBE-FORWARD (1 references)
target     prot opt source               destination         
DROP       all  --  anywhere             anywhere             ctstate INVALID
ACCEPT     all  --  anywhere             anywhere             /* kubernetes forwarding rules */ mark match 0x4000/0x4000
ACCEPT     all  --  anywhere             anywhere             /* kubernetes forwarding conntrack rule */ ctstate RELATED,ESTABLISHED

Chain KUBE-PROXY-FIREWALL (3 references)
target     prot opt source               destination         

Chain IFW (1 references)
target     prot opt source               destination         
DROP       all  --  anywhere             anywhere             u32 "0x0>>0x1c&0xf=0x4&&0xc&0xfff00000=0xac100000&&0x0>>0x1c&0xf=0x4&&0x9>>0x18&0xff=0x1&&0x0>>0x16&0x3c@0x0>>0x18&0xff=0x8"
DROP       all  --  anywhere             anywhere             u32 "0x0>>0x1c&0xf=0x4&&0xc&0xfff00000=0xac100000&&0x0>>0x1c&0xf=0x4&&0x9>>0x18&0xff=0x6&&0x0>>0x16&0x3fc@0x2>>0x10&0xffff=0x1f40:0x2328"
RETURN     all  --  anywhere             anywhere        
```